### PR TITLE
fix: replaced rust-crypto dep with constant_time_eq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ digest = "0.10.3"
 bs58 = "0.4.0"
 rand = "0.8.5"
 hex = "0.4.3"
-rust-crypto = "0.2.36"
 sha2 = { version = "0.10.2", optional = true }
+constant_time_eq = "0.2.5"
 
 [dev-dependencies]
 sha2 = "0.10.2"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,4 +1,4 @@
-use crypto::util::fixed_time_eq;
+use constant_time_eq::constant_time_eq;
 use digest::{Digest, FixedOutputReset};
 use rand::RngCore;
 
@@ -101,11 +101,11 @@ impl<R: RngCore, D: Digest + FixedOutputReset> PrefixedApiKeyController<R, D> {
 
     /// Secure helper for checking if a given PrefixedApiKey matches a given
     /// long token hash. This uses the hashing algorithm configured on the controller
-    /// and uses the [fixed_time_eq](crypto::util::fixed_time_eq) method of comparing hashes
+    /// and uses the [constant_time_eq](constant_time_eq::constant_time_eq) method of comparing hashes
     /// to avoid possible timing attacks.
     pub fn check_hash(&mut self, pak: &PrefixedApiKey, hash: String) -> bool {
         let pak_hash = self.long_token_hashed(pak);
-        fixed_time_eq(pak_hash.as_bytes(), hash.as_bytes())
+        constant_time_eq(pak_hash.as_bytes(), hash.as_bytes())
     }
 }
 


### PR DESCRIPTION
this fixes a build issue I wasn't aware of on m1/m2 macs, and generally improves dependency hygiene since rust-crypto hasn't been updated in a long time.