### PR TITLE
fix: use a proper struct for builder errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub use crate::prefixed_api_key::PrefixedApiKey;
 pub use crate::prefixed_api_key::PrefixedApiKeyError;
 
 mod controller_builder;
+pub use crate::controller_builder::BuilderError;
 pub use crate::controller_builder::ControllerBuilder;
 
 mod controller;


### PR DESCRIPTION
Use proper structs for better error handling with anyhow