### PR TITLE
feat: added type aliases for pak controllers

### DIFF
--- a/src/controller_alias.rs
+++ b/src/controller_alias.rs
@@ -1,0 +1,63 @@
+use crate::PrefixedApiKeyController;
+
+use rand::rngs::{OsRng, StdRng, ThreadRng};
+
+// Aliases using OsRng
+#[cfg(feature = "sha2")]
+use sha2::{Sha224, Sha256, Sha384, Sha512, Sha512_224, Sha512_256};
+
+#[cfg(feature = "sha2")]
+pub type PakControllerOsSha224 = PrefixedApiKeyController<OsRng, Sha224>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerOsSha256 = PrefixedApiKeyController<OsRng, Sha256>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerOsSha384 = PrefixedApiKeyController<OsRng, Sha384>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerOsSha512 = PrefixedApiKeyController<OsRng, Sha512>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerOsSha512_224 = PrefixedApiKeyController<OsRng, Sha512_224>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerOsSha512_256 = PrefixedApiKeyController<OsRng, Sha512_256>;
+
+// Aliases using StdRng
+#[cfg(feature = "sha2")]
+pub type PakControllerStdSha224 = PrefixedApiKeyController<StdRng, Sha224>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerStdSha256 = PrefixedApiKeyController<StdRng, Sha256>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerStdSha384 = PrefixedApiKeyController<StdRng, Sha384>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerStdSha512 = PrefixedApiKeyController<StdRng, Sha512>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerStdSha512_224 = PrefixedApiKeyController<StdRng, Sha512_224>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerStdSha512_256 = PrefixedApiKeyController<StdRng, Sha512_256>;
+
+// Aliases using ThreadRng
+#[cfg(feature = "sha2")]
+pub type PakControllerThreadSha224 = PrefixedApiKeyController<ThreadRng, Sha224>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerThreadSha256 = PrefixedApiKeyController<ThreadRng, Sha256>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerThreadSha384 = PrefixedApiKeyController<ThreadRng, Sha384>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerThreadSha512 = PrefixedApiKeyController<ThreadRng, Sha512>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerThreadSha512_224 = PrefixedApiKeyController<ThreadRng, Sha512_224>;
+
+#[cfg(feature = "sha2")]
+pub type PakControllerThreadSha512_256 = PrefixedApiKeyController<ThreadRng, Sha512_256>;

--- a/src/controller_builder.rs
+++ b/src/controller_builder.rs
@@ -341,8 +341,13 @@ mod controller_builder_tests {
 #[cfg(test)]
 mod controller_builder_sha2_tests {
     use digest::{Digest, FixedOutputReset};
-    use rand::rngs::OsRng;
-    use rand::RngCore;
+
+    use crate::{
+        rand::rngs::OsRng, rand::rngs::StdRng, rand::rngs::ThreadRng, rand::RngCore,
+        rand::SeedableRng, BuilderError, PakControllerOsSha224, PakControllerOsSha256,
+        PakControllerOsSha384, PakControllerOsSha512, PakControllerOsSha512_224,
+        PakControllerOsSha512_256, PakControllerStdSha256, PakControllerThreadSha256,
+    };
 
     use super::{ControllerBuilder, PrefixedApiKeyController};
 
@@ -357,13 +362,14 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_digest_sha224() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .rng(OsRng)
-            .digest_sha256()
-            .short_token_prefix(None)
-            .default_lengths()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha224, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .rng(OsRng)
+                .digest_sha224()
+                .short_token_prefix(None)
+                .default_lengths()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()
@@ -372,13 +378,14 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_digest_sha256() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .rng(OsRng)
-            .digest_sha256()
-            .short_token_prefix(None)
-            .default_lengths()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha256, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .rng(OsRng)
+                .digest_sha256()
+                .short_token_prefix(None)
+                .default_lengths()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()
@@ -387,13 +394,14 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_digest_sha384() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .rng(OsRng)
-            .digest_sha384()
-            .short_token_prefix(None)
-            .default_lengths()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha384, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .rng(OsRng)
+                .digest_sha384()
+                .short_token_prefix(None)
+                .default_lengths()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()
@@ -402,13 +410,14 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_digest_sha512() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .rng(OsRng)
-            .digest_sha512()
-            .short_token_prefix(None)
-            .default_lengths()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha512, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .rng(OsRng)
+                .digest_sha512()
+                .short_token_prefix(None)
+                .default_lengths()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()
@@ -417,13 +426,14 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_digest_sha512_224() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .rng(OsRng)
-            .digest_sha512_224()
-            .short_token_prefix(None)
-            .default_lengths()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha512_224, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .rng(OsRng)
+                .digest_sha512_224()
+                .short_token_prefix(None)
+                .default_lengths()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()
@@ -432,13 +442,14 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_digest_sha512_256() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .rng(OsRng)
-            .digest_sha512_256()
-            .short_token_prefix(None)
-            .default_lengths()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha512_256, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .rng(OsRng)
+                .digest_sha512_256()
+                .short_token_prefix(None)
+                .default_lengths()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()
@@ -447,10 +458,11 @@ mod controller_builder_sha2_tests {
 
     #[test]
     fn ok_with_seam_deafults() {
-        let controller_result = ControllerBuilder::new()
-            .prefix("mycompany".to_owned())
-            .seam_defaults()
-            .finalize();
+        let controller_result: Result<PakControllerOsSha256, BuilderError> =
+            ControllerBuilder::new()
+                .prefix("mycompany".to_owned())
+                .seam_defaults()
+                .finalize();
         assert!(controller_result.is_ok());
         assert!(controller_generates_matching_hash(
             controller_result.unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ pub use crate::controller_builder::ControllerBuilder;
 mod controller;
 pub use crate::controller::PrefixedApiKeyController;
 
+mod controller_alias;
+pub use controller_alias::*;
+
 // reexport rngs
 pub use rand;
 
@@ -17,5 +20,6 @@ pub use rand;
 pub use sha2;
 
 #[doc = include_str!("../README.md")]
+#[cfg(feature = "sha2")]
 #[cfg(doctest)]
 pub struct ReadmeDoctests;


### PR DESCRIPTION
- Added aliases for the pak controller
- fixed a couple small bugs with test coverage (bugs don't impact library correctness, just test efficacy).

Resolves https://github.com/brahmlower/prefixed-api-key/issues/17