### PR TITLE
chore: bump msrv to 1.61.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.60.0  # Minimum Supported Rust Version
+          - 1.61.0  # Minimum Supported Rust Version
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.2.0"
 edition = "2021"
 
 [package.metadata]
-msrv = "1.60.0"
+msrv = "1.61.0"
 
 [package.metadata.docs.rs]
 # Enable all feature flags so that their docs are included


### PR DESCRIPTION
The weekly tests began failing 2 weeks ago and I just never noticed. Not exactly sure what changed, but looks like several dependencies now require at least rust 1.61.0 on the `x86_64-unknown-linux-gnu` target.